### PR TITLE
Implement Tauri multi‑window and global shortcut support

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,12 +1,52 @@
-// Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
+use tauri::{self, Manager, WebviewUrl, WebviewWindowBuilder, AppHandle};
+
 #[tauri::command]
 fn greet(name: &str) -> String {
     format!("Hello, {}! You've been greeted from Rust!", name)
 }
 
+fn open_or_focus(app: &AppHandle, label: &str, title: &str) {
+    if let Some(win) = app.get_webview_window(label) {
+        let _ = win.show();
+        let _ = win.set_focus();
+    } else {
+        WebviewWindowBuilder::new(app, label, WebviewUrl::App("index.html".into()))
+            .title(title)
+            .build()
+            .expect("failed to create window");
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .setup(|app| {
+            let handle = app.handle();
+            app.global_shortcut().register("CmdOrCtrl+Alt+Shift+D", move || {
+                open_or_focus(&handle, "daily-note", "Daily Note");
+            })?;
+
+            let handle = app.handle();
+            app.global_shortcut().register("CmdOrCtrl+Alt+Shift+T", move || {
+                open_or_focus(&handle, "current-task", "Current Task");
+            })?;
+
+            let handle = app.handle();
+            app.global_shortcut().register("CmdOrCtrl+Alt+Shift+S", move || {
+                if handle.get_webview_window("flex").is_none() {
+                    open_or_focus(&handle, "flex", "Flex Window");
+                } else if let Some(win) = handle.get_webview_window("flex") {
+                    let _ = win.set_focus();
+                }
+            })?;
+            Ok(())
+        })
+        .on_window_event(|event| {
+            if let tauri::WindowEvent::Destroyed = event.event() {
+                let label = event.window().label().to_string();
+                let _ = event.window().app_handle().emit_all("window-closed", label);
+            }
+        })
         .plugin(tauri_plugin_opener::init())
         .invoke_handler(tauri::generate_handler![greet])
         .run(tauri::generate_context!())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -12,8 +12,30 @@
   "app": {
     "windows": [
       {
-        "title": "mapmap-window",
+        "label": "dashboard",
+        "title": "Dashboard",
         "width": 800,
+        "height": 600
+      },
+      {
+        "label": "daily-note",
+        "title": "Daily Note",
+        "visible": false,
+        "width": 500,
+        "height": 600
+      },
+      {
+        "label": "current-task",
+        "title": "Current Task",
+        "visible": false,
+        "width": 500,
+        "height": 400
+      },
+      {
+        "label": "flex",
+        "title": "Flex Window",
+        "visible": false,
+        "width": 600,
         "height": 600
       }
     ],

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,20 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import App from "./App";
+import { appWindow } from "@tauri-apps/api/window";
+import { Dashboard, DailyNote, CurrentTask, Flex } from "./pages";
+
+const components: Record<string, React.FC> = {
+  dashboard: Dashboard,
+  "daily-note": DailyNote,
+  "current-task": CurrentTask,
+  flex: Flex,
+};
+
+const label = appWindow.label;
+const Component = components[label] ?? Dashboard;
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <App />
-  </React.StrictMode>,
+    <Component />
+  </React.StrictMode>
 );

--- a/src/pages/CurrentTask.tsx
+++ b/src/pages/CurrentTask.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+export default function CurrentTask() {
+  return (
+    <div className="window current-task">
+      <h1>Current Task</h1>
+    </div>
+  );
+}

--- a/src/pages/DailyNote.tsx
+++ b/src/pages/DailyNote.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+export default function DailyNote() {
+  return (
+    <div className="window daily-note">
+      <h1>Daily Note</h1>
+    </div>
+  );
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+export default function Dashboard() {
+  return (
+    <div className="window dashboard">
+      <h1>Dashboard</h1>
+    </div>
+  );
+}

--- a/src/pages/Flex.tsx
+++ b/src/pages/Flex.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+export default function Flex() {
+  return (
+    <div className="window flex">
+      <h1>Flex Window</h1>
+    </div>
+  );
+}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,0 +1,4 @@
+export { default as Dashboard } from "./Dashboard";
+export { default as DailyNote } from "./DailyNote";
+export { default as CurrentTask } from "./CurrentTask";
+export { default as Flex } from "./Flex";


### PR DESCRIPTION
## Summary
- add individual React pages for each Tauri window
- dynamically mount the page according to the window label
- define four windows in `tauri.conf.json`
- manage windows and register global shortcuts in Rust

## Testing
- `pnpm build` *(fails: Cannot find module 'react' etc.)*
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails to download crates)*
