### PR TITLE
Fix compile errors with Tauri v2

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
+tauri-plugin-global-shortcut = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 


### PR DESCRIPTION
## Summary
- support global shortcuts by adding the plugin
- adjust window event callback for latest Tauri API

## Testing
- `cargo check` *(fails: failed to download crates)*
- `npm run build` *(fails: cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6840011c80508324bf5e64d83776c1aa